### PR TITLE
オフライン対応

### DIFF
--- a/Assets/Scripts/UnityModule/AssetBundleManagement/Loader.cs
+++ b/Assets/Scripts/UnityModule/AssetBundleManagement/Loader.cs
@@ -270,6 +270,9 @@ namespace UnityModule.AssetBundleManagement {
                 Directory.CreateDirectory(System.IO.Path.GetDirectoryName(CreateLocalSingleManifestPath()));
             }
             File.WriteAllBytes(CreateLocalSingleManifestPath(), data);
+#if UNITY_IOS
+            UnityEngine.iOS.Device.SetNoBackupFlag(CreateLocalSingleManifestPath());
+#endif
         }
 
         private static IObservable<AssetBundle> LoadSingleManifest(IURLResolver urlResolverSingleManifest) {

--- a/Assets/Scripts/UnityModule/AssetBundleManagement/Loader.cs
+++ b/Assets/Scripts/UnityModule/AssetBundleManagement/Loader.cs
@@ -179,7 +179,7 @@ namespace UnityModule.AssetBundleManagement {
                                     // UnityWebRequest に変換
                                     .SelectMany(
                                         __ => ObservableUnityWebRequest
-                                            .GetAssetBundle(this.URLResolverNormal.Resolve(assetBundleName), 0, null, this.GetProgress(assetBundleName))
+                                            .GetAssetBundle(this.URLResolverNormal.Resolve(assetBundleName), this.SingleManifest.GetAssetBundleHash(assetBundleName), 0, null, this.GetProgress(assetBundleName))
                                             // 読み込み完了時に読み込み済マップに入れておく
                                             //   AssetBundle を開きっぱなしにしておくコストは殆ど無いとのことなので、Unload は原則行わない
                                             //   See also: http://tsubakit1.hateblo.jp/entry/2016/08/23/233604 の「SceneをAssetBundleに含める方法」セクションの最後


### PR DESCRIPTION
* SingleManifest をローカルストレージにキャッシュし、二回目以降オフラインでも動作するようにする
  * AppStore リジェクト対応も忘れずに
* 個別の AssetBundle ダウンロード時に、ちゃんとハッシュをチェックする
  * コレをしないと、毎回新規ダウンロード扱いになる模様
