### PR TITLE
エディタで AssetBundle をビルドするときにハッシュ値の計算がおかしくなるコトがある問題を修正

### DIFF
--- a/Assets/Scripts/UnityModule/AssetBundleManagement/Loader.cs
+++ b/Assets/Scripts/UnityModule/AssetBundleManagement/Loader.cs
@@ -212,6 +212,12 @@ namespace UnityModule.AssetBundleManagement {
             return this.ProgressSummary.Select(x => x / this.Count).AsObservable();
         }
 
+        public static void ClearCachedSingleManifest() {
+            if (HasSingleManifest()) {
+                File.Delete(CreateLocalSingleManifestPath());
+            }
+        }
+
         public void Dispose() {
             this.LoadedAssetBundleMap
                 .ToList()


### PR DESCRIPTION
* Editor 上で AssetBundle ビルドを行うと、Standalone, iOS, Android のうち最も先にビルドしたモノがキャッシュされてしまうため、キャッシュを削除できないと永遠に誤った SingleManifest を参照して Hash 計算を行ってしまう